### PR TITLE
Add multi-site support

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,25 @@ export default defineConfig({
   testDir: './tests',
   reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }]],
   use: {
-    baseURL: 'https://partnerinpublishing.com',
     headless: true,
     ignoreHTTPSErrors: true,
   },
+  projects: [
+    {
+      name: 'pip',
+      use: { baseURL: 'https://partnerinpublishing.com' },
+    },
+    {
+      name: 'gradepotential',
+      use: { baseURL: 'https://gradepotentialtutoring.ue1.rapydapps.cloud' },
+    },
+    {
+      name: 'itopia',
+      use: { baseURL: 'https://itopia.com' },
+    },
+    {
+      name: 'metricmarine',
+      use: { baseURL: 'https://www.metricmarine.com' },
+    },
+  ],
 });

--- a/src/app/api/run-test/route.ts
+++ b/src/app/api/run-test/route.ts
@@ -8,10 +8,11 @@ const historyFile = path.join(process.cwd(), "data", "testHistory.json");
 export async function POST(req: Request) {
   const body = await req.json();
   const testPath = body.testPath || "";
+  const project = body.project || "";
 
-  const args = testPath
-  ? ["playwright", "test", testPath]
-  : ["playwright", "test"];
+  const args = ["playwright", "test"];
+  if (testPath) args.push(testPath);
+  if (project) args.push("--project", project);
 
   const child = spawn("npx", args, {
     cwd: process.cwd(),

--- a/src/components/TestContent.tsx
+++ b/src/components/TestContent.tsx
@@ -11,6 +11,12 @@ import {
 } from "../../components/ui/select";
 import { Button } from "../../components/ui/button";
 import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../../components/ui/card";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -20,6 +26,29 @@ import {
 
 export default function TestContent() {
   const [selectedTest, setSelectedTest] = useState("");
+  const [selectedSite, setSelectedSite] = useState("pip");
+  const sites = [
+    {
+      project: "pip",
+      name: "Partner in Publishing",
+      url: "https://partnerinpublishing.com",
+    },
+    {
+      project: "gradepotential",
+      name: "Grade Potential",
+      url: "https://gradepotentialtutoring.ue1.rapydapps.cloud",
+    },
+    {
+      project: "itopia",
+      name: "Itopia",
+      url: "https://itopia.com",
+    },
+    {
+      project: "metricmarine",
+      name: "Metric Marine",
+      url: "https://www.metricmarine.com",
+    },
+  ];
   const [logLines, setLogLines] = useState<string[]>([]);
   const [logOpen, setLogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +67,10 @@ export default function TestContent() {
     const res = await fetch("/api/run-test", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ testPath: testToRun === "all" ? "" : testToRun }),
+      body: JSON.stringify({
+        testPath: testToRun === "all" ? "" : testToRun,
+        project: selectedSite,
+      }),
     });
 
     if (!res.body) {
@@ -106,6 +138,26 @@ export default function TestContent() {
         <h2 className="text-2xl font-semibold text-white drop-shadow-[0_0_8px_#00ffff80]">
           ⚡ Automated Test Runner
         </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+          {sites.map((site) => (
+            <Card
+              key={site.project}
+              onClick={() => setSelectedSite(site.project)}
+              className={`cursor-pointer hover:bg-gray-800/40 ${
+                selectedSite === site.project ? "border-blue-500 bg-gray-800/40" : "border-gray-700"
+              }`}
+            >
+              <CardHeader>
+                <CardTitle className="text-sm text-white">{site.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-gray-400 break-all">{site.url}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
         <div className="flex flex-wrap gap-4">
 
           {/* SELECT DE TEST */}


### PR DESCRIPTION
## Summary
- configure Playwright projects for several sites
- allow selecting project in the test runner API
- add site cards on the dashboard to pick a site

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_688a7f8f392c832985f5048a520483d0