### PR TITLE
Add Deepseek chat modal to dashboard

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,57 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import DeepseekChat from '../../components/DeepseekChat';
 
 export default function ChatPage() {
-  const [input, setInput] = useState('');
-  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const sendMessage = async () => {
-    if (!input) return;
-    const userMessage = { role: 'user', content: input };
-    setMessages((msgs) => [...msgs, userMessage]);
-    setInput('');
-    setLoading(true);
-
-    try {
-      const res = await fetch('/api/deepseek', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: userMessage.content }),
-      });
-      const data = await res.json();
-      const reply = data.choices?.[0]?.message?.content || 'No response';
-      setMessages((msgs) => [...msgs, { role: 'assistant', content: reply }]);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div className="p-4 max-w-xl mx-auto">
-      <div className="mb-4 space-y-2">
-        {messages.map((m, i) => (
-          <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
-            <span className="px-2 py-1 rounded bg-gray-200 inline-block">{m.content}</span>
-          </div>
-        ))}
-      </div>
-      <div className="flex gap-2">
-        <input
-          className="flex-1 border px-2 py-1"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-        />
-        <button
-          className="border px-4 py-1"
-          onClick={sendMessage}
-          disabled={loading}
-        >
-          {loading ? '...' : 'Enviar'}
-        </button>
-      </div>
-    </div>
-  );
+  return <DeepseekChat />;
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,15 @@ import {
   SidebarTrigger,
 } from "../components/ui/sidebar";
 
-import { FlaskConical, FileText, History } from "lucide-react";
+import { FlaskConical, FileText, History, MessageCircle } from "lucide-react";
+import DeepseekChat from "../components/DeepseekChat";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
 
 export default function DashboardPage() {
   const [tab, setTab] = useState<"test" | "history" | "temp" | "ClarityKPIs" |  "ClarityDevicesChart" | "ClarityTopPages">(
@@ -128,6 +136,19 @@ export default function DashboardPage() {
           </div>
         </SidebarInset>
       </div>
+      <Dialog>
+        <DialogTrigger asChild>
+          <button className="fixed bottom-4 right-4 rounded-full bg-blue-500 text-white p-3 shadow-lg">
+            <MessageCircle className="w-5 h-5" />
+          </button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Deepseek Chat</DialogTitle>
+          </DialogHeader>
+          <DeepseekChat />
+        </DialogContent>
+      </Dialog>
     </SidebarProvider>
   );
 }

--- a/src/components/DeepseekChat.tsx
+++ b/src/components/DeepseekChat.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function DeepseekChat() {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const userMessage = { role: 'user', content: input };
+    setMessages((msgs) => [...msgs, userMessage]);
+    setInput('');
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/deepseek', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: userMessage.content }),
+      });
+      const data = await res.json();
+      const reply = data.choices?.[0]?.message?.content || 'No response';
+      setMessages((msgs) => [...msgs, { role: 'assistant', content: reply }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <div className="mb-4 space-y-2 max-h-80 overflow-auto">
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+            <span className="px-2 py-1 rounded bg-gray-200 inline-block">{m.content}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border px-2 py-1"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+        />
+        <button
+          className="border px-4 py-1"
+          onClick={sendMessage}
+          disabled={loading}
+        >
+          {loading ? '...' : 'Enviar'}
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate Deepseek chat into dashboard with floating icon and modal
- factor chat interface into reusable `DeepseekChat` component

## Testing
- `npm test` *(failed: ran partially, 132 did not run)*
- `npm run lint` *(failed: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68935e846b7c8329a0235834bb89d5e5