### PR TITLE
feat: enhance chat assistant with test history search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fuse.js": "^7.0.0",
         "lucide-react": "^0.525.0",
         "next": "15.4.2",
         "react": "19.1.0",
@@ -4319,6 +4320,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "recharts": "^3.1.0",
     "sweetalert2": "^11.22.2",
     "swr": "^2.3.4",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "fuse.js": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/deepseek/route.ts
+++ b/src/app/api/deepseek/route.ts
@@ -1,24 +1,71 @@
 import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import Fuse from 'fuse.js';
+
+const ASSISTANT_PREFIX =
+  'Soy un asistente virtual diseñado para apoyar en el análisis de los resultados de los tests.';
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();
 
-  if (!process.env.DEEPSEEK_API_KEY) {
-    return NextResponse.json({ error: 'DEEPSEEK_API_KEY not set' }, { status: 500 });
+  let responseText: string | null = null;
+
+  try {
+    const filePath = path.join(process.cwd(), 'data', 'testHistory.json');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const history: any[] = JSON.parse(content);
+
+    const fuse = new Fuse(history, {
+      keys: ['testPath', 'project', 'errors', 'screenshots', 'videos'],
+      threshold: 0.4,
+    });
+
+    const results = fuse.search(prompt);
+
+    if (results.length > 0) {
+      const formatted = results.slice(0, 3).map((r) => {
+        const item = r.item as any;
+        return `${item.project} - ${item.testPath}: ${item.passed} pasados, ${item.failed} fallados el ${new Date(item.date).toLocaleString()}`;
+      });
+      responseText = `${ASSISTANT_PREFIX} Según el historial de pruebas, los resultados más relacionados son:\n${formatted.join('\n')}`;
+    }
+  } catch {
+    // If reading or parsing fails, fallback to DeepSeek
   }
 
-  const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.DEEPSEEK_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: 'deepseek-chat',
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  });
+  if (!responseText) {
+    if (!process.env.DEEPSEEK_API_KEY) {
+      return NextResponse.json(
+        {
+          choices: [
+            {
+              message: {
+                content: `${ASSISTANT_PREFIX} No se ha configurado la clave DEEPSEEK_API_KEY.`,
+              },
+            },
+          ],
+        },
+        { status: 500 }
+      );
+    }
 
-  const data = await response.json();
-  return NextResponse.json(data);
+    const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.DEEPSEEK_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'deepseek-chat',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const deepSeekText = data.choices?.[0]?.message?.content ?? 'No response';
+    responseText = `${ASSISTANT_PREFIX} ${deepSeekText}`;
+  }
+
+  return NextResponse.json({ choices: [{ message: { content: responseText } }] });
 }


### PR DESCRIPTION
## Summary
- prefix assistant responses with a consistent identity statement
- answer questions from `testHistory.json` using Fuse.js semantic search
- fall back to DeepSeek API when no relevant history match is found and always include the identity prefix

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689439216cf083299d9046129186c1fe