### PR TITLE
Show test errors in history table

### DIFF
--- a/src/app/api/run-test/route.ts
+++ b/src/app/api/run-test/route.ts
@@ -123,6 +123,13 @@ export async function POST(req: Request) {
         const passed = allLines.filter((l) => /\b\d+\spassed\b/.test(l)).length;
         const failed = allLines.filter((l) => /\b\d+\sfailed\b/.test(l)).length;
 
+        // Extract plain text error lines from the process output as a fallback
+        const lineErrors = allLines
+          .filter((l) => l.toLowerCase().includes("error"))
+          .slice(0, 10);
+        errors.push(...lineErrors);
+        const uniqueErrors = Array.from(new Set(errors)).slice(0, 10);
+
         const entry = {
           id: Date.now(),
           date: new Date().toISOString(),
@@ -132,7 +139,7 @@ export async function POST(req: Request) {
           failed,
           screenshots,
           videos,
-          errors,
+          errors: uniqueErrors,
         };
 
         try {

--- a/src/components/TestHistory.tsx
+++ b/src/components/TestHistory.tsx
@@ -127,7 +127,7 @@ export default function TestHistory() {
                     </TableCell>
                     <TableCell className="p-3">
                       {h.errors?.length > 0 ? (
-                        <ul className="list-disc list-inside text-red-500 text-sm">
+                        <ul className="list-disc list-inside text-red-500 text-sm max-h-32 overflow-y-auto">
                           {h.errors.map((e: string, idx: number) => (
                             <li key={idx}>{e}</li>
                           ))}


### PR DESCRIPTION
## Summary
- Capture error lines from test run output and merge with errors extracted from reports
- Display errors column in Test History with scroll support

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68adbebc6f948329849062b97a1cf85a