### PR TITLE
Add Playwright tests for Partner in Publishing

### DIFF
--- a/tests/pip/home/form-validation.spec.ts
+++ b/tests/pip/home/form-validation.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "/";
+
+test("Contact form prevents submission when required fields are empty", async ({ page }) => {
+  await page.goto(BASE_URL);
+
+  // Wait for the contact form to be visible
+  await expect(page.locator("#wpforms-form-22096")).toBeVisible();
+
+  // Attempt to submit the form without filling any fields
+  await page.click("#wpforms-submit-22096");
+
+  // The form should be invalid due to HTML5 required attributes
+  const isValid = await page.$eval(
+    "#wpforms-form-22096",
+    (form) => (form as HTMLFormElement).checkValidity()
+  );
+  expect(isValid).toBeFalsy();
+});

--- a/tests/pip/services/services-links.spec.ts
+++ b/tests/pip/services/services-links.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test("Service page links load successfully", async ({ page, context }) => {
+  await page.goto("/services/");
+
+  const links = await page.$$eval("a", (elements) =>
+    Array.from(new Set(
+      elements
+        .map((el) => el.getAttribute("href"))
+        .filter(
+          (href) =>
+            href &&
+            href.startsWith("https://partnerinpublishing.com/services/") &&
+            href !== "https://partnerinpublishing.com/services/"
+        )
+    ))
+  );
+
+  for (const href of links) {
+    const newPage = await context.newPage();
+    const response = await newPage.goto(href, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000,
+    });
+    expect(response?.status(), `${href} returned an unexpected status`).toBeLessThan(400);
+    await expect(newPage.locator("body")).toBeVisible();
+    await newPage.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add test ensuring contact form requires required fields before submission
- add test to confirm all service page links return successful responses

## Testing
- `npx playwright test tests/pip/home/form-validation.spec.ts tests/pip/services/services-links.spec.ts --project=pip --reporter=list`


------
https://chatgpt.com/codex/tasks/task_e_68b07d7c51dc8329a7991d1819aaae3d